### PR TITLE
Add new lsp setting to be able to enable/disable the LSP

### DIFF
--- a/vscode/extension.js
+++ b/vscode/extension.js
@@ -3,10 +3,14 @@ const { window, workspace, commands, ExtensionContext, Uri } = require('vscode')
 const { LanguageClient } = require('vscode-languageclient');
 
 let client = null;
+const config = workspace.getConfiguration('c3.lsp');
 
 module.exports = {
   activate: function (context) {
-    const config = workspace.getConfiguration('c3.lsp');
+    const enabled = config.get('enable');
+    if (!enabled) {
+        return;
+    }
     const executablePath = config.get('path');
 
     const serverOptions = {
@@ -36,6 +40,9 @@ module.exports = {
   },
 
   deactivate: function () {
-    return client.stop();
+    const enabled = config.get('enable');
+    if (enabled) {
+        return client.stop();
+    }
   }
 }

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -24,6 +24,11 @@
         "configuration": {
             "title": "Language Server",
             "properties": {
+                "c3.lsp.enable": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Enables the language server"
+                },
                 "c3.lsp.path" : {
                     "type": "string",
                     "default": "c3-lsp",


### PR DESCRIPTION
Added a new setting to be able to control whether the LSP client should be enabled.
Disabled by default until I improve installation process of the Language server.