### PR TITLE
Add build support to Sublime Text

### DIFF
--- a/sublime-text/C3.sublime-build
+++ b/sublime-text/C3.sublime-build
@@ -1,0 +1,46 @@
+{
+    "selector": "source.c3",
+    "cmd": [
+        "c3c",
+        "build"
+    ],
+    "working_dir": "$folder",
+    "file_regex": "^\\((.*.[cC]3t?):(\\d+):(\\d+)\\)",
+    "variants": [
+        {
+            "name": "C3 build",
+            "cmd": [
+                "c3c",
+                "build",
+            ]
+        },
+        {
+            "name": "C3 clean",
+            "cmd": [
+                "c3c",
+                "clean",
+            ]
+        },
+        {
+            "name": "C3 test",
+            "cmd": [
+                "c3c",
+                "test",
+            ]
+        },
+        {
+            "name": "C3 benchmark",
+            "cmd": [
+                "c3c",
+                "benchmark",
+            ]
+        },
+        {
+            "name": "C3 Run",
+            "cmd": [
+                "c3c",
+                "run",
+            ]
+        },
+    ]
+}

--- a/sublime-text/README.md
+++ b/sublime-text/README.md
@@ -1,3 +1,26 @@
-`c3.sublime-syntax` adds (very basic and limited) syntax highlighting for Sublime Text 4.
+# Sublime Text Package
 
-To use it put the `c3.sublime-syntax` into your `Packages/User/` folder.
+Features:
+
+- syntax highlighting
+- build tools with support for `build`, `test`, `benchmark`, `clean` anf `run`. The `c3c` executable must be in the PATH for this to work. Build errors are parsed.
+
+To use it put this ([../sublime-build](../sublime-text)) directory into your
+`Packages/User/` folder and rename it to e.g. `c3`. The `Packages/User/`
+directory has the following paths:
+
+- Linux: `~/.config/sublime-text/Packages/User/`
+- MacOS: `~/Library/Application Support/Sublime Text/Packages/User/`
+- Windows: `%APPDATA%\Roaming\Sublime Text\Packages\User\` (`C:\Users\<username>\AppData\Roaming\Sublime Text\Packages\User\`)
+
+## Contributing
+
+[./c3.sublime-syntax](./c3.sublime-syntax) adds (very basic and limited) syntax
+highlighting for
+Sublime Text 4. To write a more complete syntax highlighting see the C grammar
+file [C syntax](https://github.com/sublimehq/Packages/blob/master/C%2B%2B/C.sublime-syntax)
+which is used by Sublime Text as example and the
+[Sublime Text Syntax Definition Reference](https://www.sublimetext.com/docs/syntax.html).
+
+[./C3.sublime-build](./C3.sublime-build) adds C3's build system integration, see
+[Sublime Text Build System Reference](https://www.sublimetext.com/docs/build_systems.html)


### PR DESCRIPTION
This adds support for `build`, `clean`, `test`, `benchmark` and `run` to Sublime Text. 

Added documentation to the README