### PR TITLE
Fix comment scopes and toggle comment metadata for Sublime Text

### DIFF
--- a/sublime-text/C3.sublime-syntax
+++ b/sublime-text/C3.sublime-syntax
@@ -463,8 +463,8 @@ contexts:
 
   comments:
     - include: line_comment
-    - include: block_comment
     - include: doc_comment
+    - include: block_comment
 
   line_comment:
     - match: '//'
@@ -477,34 +477,47 @@ contexts:
       pop: true
 
   block_comment:
-    - match: '/\*(?!\*)'
-      scope: punctuation.definition.comment.c3
+    - match: '/\*'
+      scope: punctuation.definition.comment.begin.c3
       push: block_comment_body
 
   block_comment_body:
-    - meta_scope: comment.block
+    - meta_scope: comment.block.c3
     - match: '/\*'
-      scope: punctuation.definition.comment.c3
+      scope: punctuation.definition.comment.begin.c3
       push: block_comment_body
     - match: '\*/'
-      scope: punctuation.definition.comment.c3
+      scope: punctuation.definition.comment.end.c3
       pop: true
 
   doc_comment:
-    - match: '/\*\*|<\*'
-      scope: punctuation.definition.comment.c3
+    - match: '/\*\*(?!/)'
+      scope: punctuation.definition.comment.begin.c3
       push: doc_comment_body
+    - match: '<\*'
+      scope: punctuation.definition.comment.begin.c3
+      push: doc_comment2_body
 
   doc_comment_body:
     - meta_scope: comment.block.documentation.c3
+    - match: '\*/'
+      scope: punctuation.definition.comment.end.c3
+      pop: true
+    - include: doc_comment_content
+
+  doc_comment2_body:
+    - meta_scope: comment.block.documentation.c3
+    - match: '\*>'
+      scope: punctuation.definition.comment.end.c3
+      pop: true
+    - include: doc_comment_content
+
+  doc_comment_content:
     - match: '/\*'
-      scope: punctuation.definition.comment.c3
+      scope: punctuation.definition.comment.begin.c3
       push: block_comment_body
     - match: '@(param(\s*\[&?(in|out|inout)\])?|return!?|require|fails|deprecated|ensure|pure)\s'
       scope: markup.bold
-    - match: '\*/|\*>'
-      scope: punctuation.definition.comment.c3
-      pop: true
 
   type_parens:
     - match: '\('

--- a/sublime-text/Comments.tmPreferences
+++ b/sublime-text/Comments.tmPreferences
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>scope</key>
+	<string>source.c3</string>
+	<key>settings</key>
+	<dict>
+		<key>shellVariables</key>
+		<array>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START</string>
+				<key>value</key>
+				<string>// </string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START_2</string>
+				<key>value</key>
+				<string>/*</string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_END_2</string>
+				<key>value</key>
+				<string>*/</string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_START_3</string>
+				<key>value</key>
+				<string><![CDATA[<*]]></string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>TM_COMMENT_END_3</string>
+				<key>value</key>
+				<string><![CDATA[*>]]></string>
+			</dict>
+		</array>
+	</dict>
+</dict>
+</plist>

--- a/sublime-text/syntax_test_scopes.c3
+++ b/sublime-text/syntax_test_scopes.c3
@@ -1,0 +1,35 @@
+// SYNTAX TEST "C3.sublime-syntax"
+
+/**
+ * Comment Tests
+ */
+
+// comment
+// <- comment.line.double-slash.c3 punctuation.definition.comment.c3
+ // <- comment.line.double-slash.c3 punctuation.definition.comment.c3
+//^^^^^^^^ comment.line.double-slash.c3 - punctuation
+
+    /**/
+//  ^^ comment.block.c3 punctuation.definition.comment.begin.c3
+//    ^^ comment.block.c3 punctuation.definition.comment.end.c3
+
+    /*/**/*/
+//  ^^ comment.block.c3 punctuation.definition.comment.begin.c3 - coment comment
+//    ^^ comment.block.c3 comment.block.c3 punctuation.definition.comment.begin.c3
+//      ^^ comment.block.c3 comment.block.c3 punctuation.definition.comment.end.c3
+//        ^^ comment.block.c3 punctuation.definition.comment.end.c3 - coment comment
+//          ^ - comment
+
+    /**
+// ^ - comment
+//  ^^^ comment.block.documentation.c3 punctuation.definition.comment.begin.c3
+//     ^ comment.block.documentation.c3 - punctuation
+     */
+// <- comment.block.documentation.c3
+//   ^^ comment.block.documentation.c3 punctuation.definition.comment.end.c3
+//     ^ - comment
+
+    <* */ *>
+//  ^^^^^^^^ comment.block.documentation.c3
+//  ^^ punctuation.definition.comment.begin.c3
+//        ^^ punctuation.definition.comment.end.c3


### PR DESCRIPTION
This PR...

1. changes order of doc_comment and block_comment context include to give
   doc comment related patterns precedence as they have to handle empty block comments (`/**/`).
2. adds `begin` and `end` scopes to comment punctuation
3. splits doc comment patterns to ensure only balanced `<* *>` or `/* */`
   begin and end comments. Anything else (e.g. `<* */`) would be a design
   fault of the syntax itself.
4. adds meta data for ST's `toggle_comment` command.