### PR TITLE
Update treesitter queries for the neovim plugin.

### DIFF
--- a/neovim/queries/c3/folds.scm
+++ b/neovim/queries/c3/folds.scm
@@ -1,0 +1,35 @@
+[
+  ; Top-level declarations
+  (bitstruct_declaration)
+  (enum_declaration)
+  (faultdef_declaration)
+  (func_definition)
+  (import_declaration)+
+  (interface_declaration)
+  (macro_declaration)
+  (struct_declaration)
+  ; Statements
+  (asm_block_stmt)
+  (case_stmt)
+  (defer_stmt)
+  (do_stmt)
+  (for_stmt)
+  (foreach_stmt)
+  (if_stmt)
+  (switch_stmt)
+  (while_stmt)
+  (ct_for_stmt)
+  (ct_foreach_stmt)
+  (ct_switch_stmt)
+  (ct_case_stmt)
+  (ct_if_stmt)
+  (ct_else_stmt)
+  ; Comments
+  (block_comment)
+  (doc_comment)
+  ; Initializer list
+  (initializer_list)
+] @fold
+
+(compound_stmt
+  (compound_stmt) @fold)

--- a/neovim/queries/c3/highlights.scm
+++ b/neovim/queries/c3/highlights.scm
@@ -1,37 +1,79 @@
-;; NOTE In this file later patterns are assumed to have priority!
-
-;; Punctuation
-["(" ")" "[" "]" "{" "}" "(<" ">)" "[<" ">]" "{|" "|}"] @punctuation.bracket
-[";" "," ":" "::"] @punctuation.delimiter
-
-;; Constant
-(const_ident) @constant
-["true" "false"] @boolean
-["null"] @constant.builtin
-
-;; Variable
-[(ident) (ct_ident)] @variable
-;; 1) Member
-(field_expr field: (access_ident (ident) @variable.member))
-(struct_member_declaration (ident) @variable.member)
-(struct_member_declaration (identifier_list (ident) @variable.member))
-(bitstruct_member_declaration (ident) @variable.member)
-(initializer_list (arg (param_path (param_path_element (ident) @variable.member))))
-;; 2) Parameter
-(parameter name: (_) @variable.parameter)
-(call_invocation (call_arg (ident) @variable.parameter))
-(enum_param_declaration (ident) @variable.parameter)
-;; 3) Declaration
-(global_declaration (ident) @variable.declaration)
-(local_decl_after_type name: [(ident) (ct_ident)] @variable.declaration)
-(var_decl name: [(ident) (ct_ident)] @variable.declaration)
-(try_unwrap (ident) @variable.declaration)
-(catch_unwrap (ident) @variable.declaration)
-
-;; Keyword (from `c3c --list-keywords`)
+; Punctuation
 [
-  "assert"
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+  "[<"
+  ">]"
+] @punctuation.bracket
+
+[
+  ";"
+  ","
+  ":"
+  "::"
+] @punctuation.delimiter
+
+; Constant
+(const_ident) @constant
+
+[
+  "true"
+  "false"
+] @boolean
+
+"null" @constant.builtin
+
+; Variable
+[
+  (ident)
+  (ct_ident)
+  (hash_ident)
+] @variable
+
+; 1) Member
+(field_expr
+  field: (access_ident
+    (ident) @variable.member))
+
+(struct_member_declaration
+  (ident) @variable.member)
+
+(struct_member_declaration
+  (identifier_list
+    (ident) @variable.member))
+
+(bitstruct_member_declaration
+  (ident) @variable.member)
+
+(initializer_list
+  (initializer_element
+    (param_path
+      (param_path_element
+        (access_ident (ident) @variable.member)))))
+
+; 2) Parameter
+(param
+  name: (_) @variable.parameter)
+
+(trailing_block_param
+  (at_ident) @variable.parameter)
+
+(call_arg_list
+  (call_arg
+    name: (_) @variable.parameter))
+
+(enum_param
+  (ident) @variable.parameter)
+
+; Keyword (from `c3c --list-keywords`)
+[
+  "alias"
   "asm"
+  "attrdef"
   "catch"
   "defer"
   "try"
@@ -40,12 +82,9 @@
 
 [
   "$alignof"
-  "$and"
-  "$append"
   "$assert"
   "$assignable"
   "$case"
-  "$concat"
   "$default"
   "$defined"
   "$echo"
@@ -68,7 +107,6 @@
   "$is_const"
   "$nameof"
   "$offsetof"
-  "$or"
   "$qnameof"
   "$sizeof"
   "$stringify"
@@ -78,26 +116,30 @@
   "$vacount"
   "$vatype"
   "$vaconst"
-  "$varef"
   "$vaarg"
   "$vaexpr"
   "$vasplat"
 ] @keyword.directive
 
+"assert" @keyword.debug
+
 "fn" @keyword.function
+
 "macro" @keyword.function
+
 "return" @keyword.return
+
 "import" @keyword.import
-"module" @keyword.module
+
+"module" @keyword
 
 [
   "bitstruct"
-  "def"
-  "distinct"
   "enum"
-  "fault"
+  "faultdef"
   "interface"
   "struct"
+  "typedef"
   "union"
 ] @keyword.type
 
@@ -128,36 +170,24 @@
   "tlocal"
 ] @keyword.modifier
 
-;; Operator (from `c3c --list-operators`)
+; Operator (from `c3c --list-operators`)
 [
   "&"
   "!"
   "~"
   "|"
   "^"
-  ;; ":"
-  ;; ","
-  ;; ";"
   "="
   ">"
   "/"
   "."
-  ;; "#"
   "<"
-  ;; "{"
-  ;; "["
-  ;; "("
   "-"
   "%"
   "+"
   "?"
-  ;; "}"
-  ;; "]"
-  ;; ")"
   "*"
-  ;; "_"
   "&&"
-  ;; "->"
   "!!"
   "&="
   "|="
@@ -169,9 +199,6 @@
   ">="
   "=>"
   "<="
-  ;; "{|"
-  ;; "(<"
-  ;; "[<"
   "-="
   "--"
   "%="
@@ -180,20 +207,25 @@
   "||"
   "+="
   "++"
-  ;; "|}"
-  ;; ">)"
-  ;; ">]"
   "??"
-  ;; "::"
   "<<"
   ">>"
   "..."
   "<<="
   ">>="
+  "&&&"
+  "+++"
+  "|||"
 ] @operator
 
-(range_expr ":" @operator)
-(foreach_cond ":" @operator)
+(range_expr
+  ":" @operator)
+
+(foreach_cond
+  ":" @operator)
+
+(ct_foreach_cond
+  ":" @operator)
 
 (ternary_expr
   [
@@ -207,117 +239,168 @@
     "??"
   ] @keyword.conditional.ternary)
 
-;; Literal
+; Literal
 (integer_literal) @number
+
 (real_literal) @number.float
+
 (char_literal) @character
+
 (bytes_literal) @number
 
-;; String
+; String
 (string_literal) @string
+
 (raw_string_literal) @string
 
-;; Escape Sequence
+; Escape Sequence
 (escape_sequence) @string.escape
 
-;; Builtin (constants)
-((builtin) @constant.builtin (#match? @constant.builtin "_*[A-Z][_A-Z0-9]*"))
+; Builtin (constants)
+(builtin_const) @constant.builtin
 
-;; Type Property (from `c3c --list-type-properties`)
-(type_access_expr (access_ident [(ident) "typeid"] @variable.builtin
-                                (#any-of? @variable.builtin
-                                          "alignof"
-                                          "associated"
-                                          "elements"
-                                          "extnameof"
-                                          "inf"
-                                          "is_eq"
-                                          "is_ordered"
-                                          "is_substruct"
-                                          "len"
-                                          "max"
-                                          "membersof"
-                                          "min"
-                                          "nan"
-                                          "inner"
-                                          "kindof"
-                                          "names"
-                                          "nameof"
-                                          "params"
-                                          "parentof"
-                                          "qnameof"
-                                          "returns"
-                                          "sizeof"
-                                          "values"
-                                          ;; Extra token
-                                          "typeid")))
+; Type Property (from `c3c --list-type-properties`)
+(type_access_expr
+  (access_ident
+    (ident) @variable.builtin
+    (#any-of? @variable.builtin
+      "alignof" "associated" "elements" "extnameof" "from_ordinal" "get" "inf" "is_eq" "is_ordered"
+      "is_substruct" "len" "lookup" "lookup_field" "max" "membersof" "methodsof" "min" "nan" "inner"
+      "kindof" "names" "nameof" "params" "paramsof" "parentof" "qnameof" "returns" "sizeof" "tagof"
+      "has_tagof" "values" "typeid")))
 
-;; Label
+; Label
 [
   (label)
   (label_target)
 ] @label
 
-;; Module
-(module_resolution (ident) @module)
-(module (path_ident (ident) @module))
-(import_declaration (path_ident (ident) @module))
+; Module
+(module_resolution
+  (ident) @module)
 
-;; Attribute
-(attribute name: (_) @attribute)
-(define_attribute name: (_) @attribute)
-(call_inline_attributes (at_ident) @attribute)
-(asm_block_stmt (at_ident) @attribute)
+(module_declaration
+  (path_ident
+    (ident) @module))
 
-;; Type
+(import_declaration
+  (path_ident
+    (ident) @module))
+
+; Attribute
+(attribute
+  name: (at_ident) @attribute)
+
+(at_type_ident) @attribute
+
+(call_inline_attributes
+  (at_ident) @attribute)
+
+(asm_block_stmt
+  (at_ident) @attribute)
+
+; Type
 [
   (type_ident)
   (ct_type_ident)
 ] @type
+
 (base_type_name) @type.builtin
 
-;; Function Definition
-(func_header name: (_) @function)
-(func_header method_type: (_) name: (_) @function.method)
-;; NOTE macro_declaration can also have a func_header
-(macro_header name: (_) @function)
-(macro_header method_type: (_) name: (_) @function.method)
+; Function Definition
+(func_header
+  name: (_) @function)
 
-;; Function Call
-(call_expr function: [(ident) (at_ident)] @function.call)
-(call_expr function: [(builtin)] @function.builtin.call)
-(call_expr function: (module_ident_expr ident: (_) @function.call))
-(call_expr function: (trailing_generic_expr argument: (module_ident_expr ident: (_) @function.call)))
-(call_expr function: (field_expr field: (access_ident [(ident) (at_ident)] @function.method.call))) ; NOTE Ambiguous, could be calling a method or function pointer
-;; Method on type
-(call_expr function: (type_access_expr field: (access_ident [(ident) (at_ident)] @function.method.call)))
+(func_header
+  method_type: (_)
+  name: (_) @function.method)
 
-;; Assignment
-;; (assignment_expr left: (ident) @variable.member)
-;; (assignment_expr left: (module_ident_expr (ident) @variable.member))
-;; (assignment_expr left: (field_expr field: (_) @variable.member))
-;; (assignment_expr left: (unary_expr operator: "*" @variable.member))
-;; (assignment_expr left: (subscript_expr ["[" "]"] @variable.member))
+(macro_header
+  name: (_) @function)
 
-;; (update_expr argument: (ident) @variable.member)
-;; (update_expr argument: (module_ident_expr ident: (ident) @variable.member))
-;; (update_expr argument: (field_expr field: (_) @variable.member))
-;; (update_expr argument: (unary_expr operator: "*" @variable.member))
-;; (update_expr argument: (subscript_expr ["[" "]"] @variable.member))
+(macro_header
+  method_type: (_)
+  name: (_) @function.method)
 
-;; (unary_expr operator: ["--" "++"] argument: (ident) @variable.member)
-;; (unary_expr operator: ["--" "++"] argument: (module_ident_expr (ident) @variable.member))
-;; (unary_expr operator: ["--" "++"] argument: (field_expr field: (access_ident (ident)) @variable.member))
-;; (unary_expr operator: ["--" "++"] argument: (subscript_expr ["[" "]"] @variable.member))
+; Function Call
+(call_expr
+  function: (ident_expr
+    [
+      (ident)
+      (at_ident)
+    ] @function.call))
 
-;; Asm
-(asm_instr [(ident) "int"] @function.builtin)
-(asm_expr [(ct_ident) (ct_const_ident)] @variable.builtin)
+(call_expr
+  function: (trailing_generic_expr
+    argument: (ident_expr
+      [
+        (ident)
+        (at_ident)
+      ] @function.call)))
 
-;; Comment
+; Method call
+(call_expr
+  function: (field_expr
+    field: (access_ident
+      [
+        (ident)
+        (at_ident)
+      ] @function.method.call)))
+
+; Method on type
+(call_expr
+  function: (type_access_expr
+    field: (access_ident
+      [
+        (ident)
+        (at_ident)
+      ] @function.method.call)))
+
+; Builtin call
+(call_expr
+  function: (builtin) @function.builtin)
+
+; Asm
+(asm_instr
+  [
+    (ident)
+    "int"
+  ] @function.builtin)
+
+(asm_expr
+  [
+    (ct_ident)
+    (ct_const_ident)
+  ] @variable.builtin)
+
+; Comment
 [
   (line_comment)
   (block_comment)
 ] @comment @spell
 
-(doc_comment) @comment.documentation @spell
+(doc_comment) @comment.documentation
+
+(doc_comment_text) @spell
+
+(doc_comment_contract
+  name: (_) @attribute)
+
+(doc_comment_contract
+  parameter: [
+    (ident)
+    (ct_ident)
+    (hash_ident)
+  ] @variable.parameter
+  (#set! priority 110))
+
+(doc_comment_contract
+  [
+    ":"
+    "?"
+  ] @comment.documentation
+  (#set! priority 110))
+
+(doc_comment_contract
+  description: (_) @comment.documentation
+  (#set! priority 110))

--- a/neovim/queries/c3/indents.scm
+++ b/neovim/queries/c3/indents.scm
@@ -1,0 +1,73 @@
+[
+  (compound_stmt)
+  (initializer_list)
+  (implies_body)
+  (struct_body)
+  (bitstruct_body)
+  (enum_body)
+  (interface_body)
+  (switch_body)
+  (ct_if_stmt)
+  (ct_for_stmt)
+  (ct_foreach_stmt)
+  (ct_switch_stmt)
+] @indent.begin
+
+([
+  (case_stmt)
+  (default_stmt)
+  (ct_case_stmt)
+] @indent.begin
+  (#set! indent.immediate 1))
+
+(expr_stmt
+  ";" @indent.end) @indent.begin
+
+(declaration
+  ";" @indent.end) @indent.begin
+
+(const_declaration
+  ";" @indent.end) @indent.begin
+
+(return_stmt
+  ";" @indent.end) @indent.begin
+
+(faultdef_declaration
+  ";" @indent.end) @indent.begin
+
+(macro_func_body
+  ";" @indent.end)
+
+[
+  ")"
+  "}"
+  "$endfor"
+  "$endforeach"
+  "$endswitch"
+  "$endif"
+] @indent.branch @indent.end
+
+"$else" @indent.branch
+
+([
+  (func_param_list)
+  (macro_param_list)
+  (enum_param_list)
+  (attribute_param_list)
+  (call_arg_list)
+  (paren_cond)
+  (for_cond)
+  (foreach_cond)
+  (paren_expr)
+] @indent.align
+  (#set! indent.open_delimiter "(")
+  (#set! indent.close_delimiter ")"))
+
+[
+  (block_comment)
+  (doc_comment)
+  (raw_string_literal)
+  (bytes_literal)
+] @indent.auto
+
+(string_literal) @indent.ignore

--- a/neovim/queries/c3/injections.scm
+++ b/neovim/queries/c3/injections.scm
@@ -1,0 +1,5 @@
+([
+  (line_comment)
+  (block_comment)
+] @injection.content
+  (#set! injection.language "comment"))

--- a/neovim/queries/c3/unused_queries.scm
+++ b/neovim/queries/c3/unused_queries.scm
@@ -1,0 +1,19 @@
+;; 3) Declaration
+; (declaration (identifier_list [(ident) (ct_ident)] @variable.declaration))
+; (declaration name: [(ident) (ct_ident)] @variable.declaration)
+; (var_declaration name: [(ident) (ct_ident)] @variable.declaration)
+; (try_unwrap (ident) @variable.declaration)
+; (catch_unwrap (ident) @variable.declaration)
+
+; Assignment
+; (assignment_expr left: (ident_expr (ident) @variable.member))
+; (assignment_expr left: (field_expr field: (_) @variable.member))
+; (assignment_expr left: (unary_expr operator: "*" @variable.member))
+; (assignment_expr left: (subscript_expr ["[" "]"] @variable.member))
+; (update_expr argument: (ident_expr ident: (ident) @variable.member))
+; (update_expr argument: (field_expr field: (_) @variable.member))
+; (update_expr argument: (unary_expr operator: "*" @variable.member))
+; (update_expr argument: (subscript_expr ["[" "]"] @variable.member))
+; (unary_expr operator: ["--" "++"] argument: (ident_expr (ident) @variable.member))
+; (unary_expr operator: ["--" "++"] argument: (field_expr field: (access_ident (ident)) @variable.member))
+; (unary_expr operator: ["--" "++"] argument: (subscript_expr ["[" "]"] @variable.member))


### PR DESCRIPTION
The treesitter queries for the neovim plugin are not up to date with the queries currently listed at c3lang/tree-sitter-c3 repo. This PR would replace the current queries with the up to date ones from the c3lang/tree-sitter-c3 repo.

Not sure if this is the intended way to keep them in sync, but figured I would open this pr to at least point it out. 

Spawned from [this comment](https://github.com/c3lang/tree-sitter-c3/issues/30#issuecomment-2797670450).