### PR TITLE
Update and improve syntax highlighting for kakoune

### DIFF
--- a/kakoune/c3.kak
+++ b/kakoune/c3.kak
@@ -1,99 +1,56 @@
-hook global BufCreate .*[.]c3i? %{
-    set-option buffer filetype c3
+hook global BufCreate .*[.]c3[it]? %{
+	set-option buffer filetype c3
 }
 
 hook -group c3-highlight global WinSetOption filetype=c3 %{
-#    require-module c3
+	require-module c3
 
-    add-highlighter window/c3 ref c3
-    hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/c3 }
+	add-highlighter window/c3 ref c3
+	hook -once -always window WinSetOption filetype=.* %{ remove-highlighter window/c3 }
 }
 
 
-# provide-module c3 %{
+provide-module c3 %{
 
 addhl shared/c3                   regions
-addhl shared/c3/global            default-region regions
-addhl shared/c3/global/code       default-region group
-# addhl shared/c3/local/code        region -recurse '\{' '^\s*(?:fn|macro)[^)]+?\)[^;]*\{' '\}' regions
-addhl shared/c3/local             region -recurse '\{' '\{' '\}' regions
-addhl shared/c3/local/code        default-region group
-
-# TODO: this does not work with 'fn void test() => {|<multiple lines>|};'
-addhl shared/c3/lambda            region '=>' ';' regions
-addhl shared/c3/lambda/code       default-region group
+addhl shared/c3/code              default-region group
 
 addhl shared/c3/comment-line      region '//' '$' fill comment
 addhl shared/c3/comment-block     region -recurse '/\*' /\*  \*/ fill comment
-addhl shared/c3/comment-doc       region <\* \*> fill comment
+addhl shared/c3/comment-doc       region <\*(?!>) \*> fill comment
 addhl shared/c3/double-string     region 'c?"' (?<!\\)(\\\\)*" fill string
 addhl shared/c3/single-string     region "'" (?<!\\)(\\\\)*' fill string
-addhl shared/c3/compiler-builtin  region '\$\$\w' '\b' fill keyword
+addhl shared/c3/literal-string    region "`" (?<!\\)(\\\\)*` fill string
 
-# The order that the highlighters are defined is VERY important as the last one defined has priority
+addhl shared/c3/code/num          regex '\b[+-]?(?:0(?:[xX][0-9a-fA-F](?:_*[0-9a-fA-F])*|[oO][0-7](?:_*[0-7])*|[bB][10](?:_*[10])*)|[0-9](?:_*[0-9])*(?:_*[eE][+-]?[0-9]+)?)(?:i8|i16|i32|i64|i128|u8|u16|u32|u|u64|u128|f|f32|f64)?\b' 0:value
+addhl shared/c3/code/ident        regex '\$?\b_*[A-Z]\w*\b' 0:value
+addhl shared/c3/code/user-attr    regex '@[A-Z]\w*\b' 0:attribute
+addhl shared/c3/code/func         regex '(?:@|#)?\w+\s*(?=\()' 0:function
+
+addhl shared/c3/code/module-start regex '(?:module|import)\s*(\w+)' 0:keyword 1:module
+addhl shared/c3/code/module       regex '\w*?(?=::)' 0:module
+addhl shared/c3/code/module-end   regex '(?<=::)(\w*?)(?:(?:\{.*?\})?;)' 1:module
+
 evaluate-commands %sh{
-    keywords='
-	asm assert bitstruct break case catch const continue
-	def default defer distinct do else enum extern
-	false fault for foreach foreach_r fn tlocal if
-	inline import macro module nextcase null return static
-	struct switch true try union var while
-    '
+	# generated using "c3c --list-{} | string join ' '" in fish
+	keywords='alias assert asm attrdef bitstruct break case catch const continue default defer do else enum extern false faultdef for foreach foreach_r fn tlocal if inline import macro module nextcase null interface return static struct switch true try typedef union var while'
+	attributes='@align @benchmark @bigendian @builtin @callconv @compact @const @deprecated @dynamic @export @extern @finalizer @format @if @inline @init @link @littleendian @local @maydiscard @naked @noalias @nodiscard @noinit @noinline @nopadding @norecurse @noreturn @nosanitize @nostrip @obfuscate @operator @operator_r @operator_s @optional @overlap @packed @private @public @pure @reflect @safemacro @section @tag @test @unused @used @wasm @weak @winmain'
+	builtins='$$abs $$any_make $$atomic_load $$atomic_store $$atomic_fetch_exchange $$atomic_fetch_add $$atomic_fetch_sub $$atomic_fetch_and $$atomic_fetch_nand $$atomic_fetch_or $$atomic_fetch_xor $$atomic_fetch_max $$atomic_fetch_min $$atomic_fetch_inc_wrap $$atomic_fetch_dec_wrap $$bitreverse $$breakpoint $$bswap $$ceil $$compare_exchange $$copysign $$cos $$clz $$ctz $$add $$div $$mod $$mul $$neg $$sub $$exp $$exp2 $$expect $$expect_with_probability $$floor $$fma $$fmuladd $$frameaddress $$fshl $$fshr $$gather $$get_rounding_mode $$log $$log10 $$log2 $$masked_load $$masked_store $$max $$memcpy $$memcpy_inline $$memmove $$memset $$memset_inline $$min $$nearbyint $$overflow_add $$overflow_mul $$overflow_sub $$popcount $$pow $$pow_int $$prefetch $$reduce_add $$reduce_and $$reduce_fadd $$reduce_fmul $$reduce_max $$reduce_min $$reduce_mul $$reduce_or $$reduce_xor $$reverse $$returnaddress $$rint $$round $$roundeven $$sat_add $$sat_shl $$sat_sub $$scatter $$select $$set_rounding_mode $$str_hash $$str_upper $$str_lower $$str_find $$swizzle $$swizzle2 $$sin $$sqrt $$syscall $$sysclock $$trap $$trunc $$unaligned_load $$unaligned_store $$unreachable $$veccomplt $$veccomple $$veccompgt $$veccompge $$veccompeq $$veccompne $$volatile_load $$volatile_store $$wasm_memory_size $$wasm_memory_grow $$wstr16 $$wstr32 $$DATE $$FILE $$FILEPATH $$FUNC $$FUNCTION $$LINE $$LINE_RAW $$MODULE $$BENCHMARK_NAMES $$BENCHMARK_FNS $$TEST_NAMES $$TEST_FNS $$TIME'
+	# Manually extracted from c3c --list-keywords
+	types='void bool char double float float16 bfloat int128 ichar int iptr isz long short uint128 uint ulong uptr ushort usz float128 any fault typeid'
+	# Needs to be separate from keywords due to the '$' prefix causing issues with '\b' resulting in things like '$endfor' not being highlighted at all
+	comptime_keywords='alignof assert assignable case default defined echo else embed endfor endforeach endif endswitch eval evaltype error exec extnameof feature for foreach if include is_const nameof offsetof qnameof sizeof stringify switch typefrom typeof vacount vatype vaconst vaarg vaexpr vasplat'
 
-    builtins='
-	switch default case if typeof else sizeof for
-	case foreach endif endfor endforeach endswitch
-	alignof append assert assignable defined echo
-	embed error eval evaltype exec extnameof qnameof
-	nameof feature is_const nameof offsetof qnameof
-	vacount vaconst vaexpr varef vasplat vatype
-	sizeof stringify typeof typefrom
-    '
+	# Both joins with a separator and escapes '$' characters
+	join() { sep=$2; eval set -- $1; IFS="$sep"; echo "$*" | sed -e 's/\$/\\\$/g'; }
 
-    types='
-	any anyfault bool char ichar short ushort int
-	uint long ulong int128 uint128 isz usz iptr
-	uptr float16 float double float128 typeid void
-    '
-
-    join() { sep=$2; eval set -- $1; IFS="$sep"; echo "$*"; }
-
-    all="local global lambda"
-    for region in ${all}; do
 	printf %s "
-	addhl shared/c3/${region}/code/keyword  regex '\\b(?:$(join "${keywords}" '|'))\\b' 0:keyword
-	addhl shared/c3/${region}/code/builtin  regex '[$]\\b(?:$(join "${builtins}" '|'))\\b' 0:keyword
-	addhl shared/c3/${region}/code/bool       regex '\\b(?:true|false)\\b' 0:keyword
-	addhl shared/c3/${region}/code/type       regex '\\b(?:$(join "${types}" '|'))\\b' 0:type
-	addhl shared/c3/${region}/code/operator   regex '(?:\\.|>|<|=|\\+|-|\\*|/|%|&|\\^|\\||!|:|\\?|;|,|@)=?' 0:default
-	addhl shared/c3/${region}/code/num        regex '(?<=[^A-Za-z0-9])[+-]?(?:0(?:[xX][0-9a-fA-F](?:_|[0-9a-fA-F])*|[oO][0-7](?:_|[0-7])*|[bB][10](?:_|[10])*)|[0-9](?:_?[0-9])*(?:_?[eE][+-]?[0-9]+)?)(?:i8|i16|i32|i64|i128|u8|u16|u32|u|u64|u128|f|f32|f64)?\b' 0:value
-	addhl shared/c3/${region}/code/const-and-struct   regex '\\\$?\\b[A-Z]\\w*\\b' 0:value
-
-	addhl shared/c3/${region}/comment-line      region '//' '$' fill comment
-	addhl shared/c3/${region}/comment-block     region /\\*  \\*/ fill comment
-	addhl shared/c3/${region}/comment-doc       region <\\* \\*> fill comment
-	addhl shared/c3/${region}/double-string     region 'c?\"' (?<!\\\\)(\\\\\\\\)*\" fill string
-	addhl shared/c3/${region}/single-string     region \"'\" (?<!\\\\)(\\\\\\\\)*' fill string
-	addhl shared/c3/${region}/compiler-builtin  region '\\$\\$\\w' '\\b' fill keyword
+	addhl shared/c3/code/keywords          regex '\b(?:$(join '${keywords}' '|'))\\b' 0:keyword
+	addhl shared/c3/code/comptime-keywords regex '[$](?:$(join '${comptime_keywords}' '|'))\\b' 0:keyword
+	addhl shared/c3/code/builtins          regex '(?:$(join '${builtins}' '|'))\\b' 0:keyword
+	addhl shared/c3/code/attributes        regex '(?:$(join '${attributes}' '|'))\\b' 0:attribute
+	addhl shared/c3/code/types             regex '\\b(?:$(join '${types}' '|'))\\b' 0:type
 	"
-    done
-
-    local="local lambda"
-    for region in ${local}; do
-	printf %s "
-	addhl shared/c3/${region}/code/module  regex '\\b(\\w+)(?:::)' 1:module
-	addhl shared/c3/${region}/code/function regex '[@#]?\\b(?![A-Z0-9])(?<!\\$)\\w+?(?=\\()' 0:function
-	addhl shared/c3/${region}/code/attribute  regex '(?:\\w+\\s)(@\\w+)\\s*(?:(?=;)|(?==))' 1:attribute
-	"
-    done
-
-    printf %s "
-	addhl shared/c3/global/code/module-statement-start   regex '(?:module|import)\\s*(\\w+)' 1:module
-	addhl shared/c3/global/code/module-statement-cont   regex '::(\\w*).*?(?:(?=::)|(?=;))' 1:module
-	addhl shared/c3/global/code/function-statement   regex '(?:(?:fn|macro) +(?:[A-Za-z0-9_\\[\\]]*\\**!? +)?(?:[^ \\t]+\\.)?)(@?[a-z]\\w+(?=\\())' 1:function
-	addhl shared/c3/global/code/attribute regex '[@][a-z]+' 0:attribute
-    "
 }
 
-# }
-
+}


### PR DESCRIPTION
I made some mistakes by overcomplicating the previous highlighter, causing interesting edge cases like this:
![image](https://github.com/user-attachments/assets/fc77bc14-0aec-4d7b-b2e1-c68b86e26f4c)
where the string highlighting ends with a semicolon due to me misusing kakoune highlighting regions unnecessarily.
I have fixed the issues caused by the regions by removing them, as well as some other issues, and updated with the new keywords & syntax changes in 0.7