### PR TITLE
Kakoune: Add a shebang comment highlighter

### DIFF
--- a/kakoune/c3.kak
+++ b/kakoune/c3.kak
@@ -30,6 +30,7 @@ addhl shared/c3/code/func         regex '(?:[@#$])?\b_*[a-z][a-zA-Z0-9_]*\s*(?=\
 addhl shared/c3/code/module       regex '([a-z0-9_]+)(?=::)' 1:module
 # code/module-decl highlights '::' as modules, but they should not be highlighted
 addhl shared/c3/code/namespace    regex '::' 0:Default
+addhl shared/c3/code/shebang      regex '\A#! ?/.*?\n' 0:comment
 
 evaluate-commands %sh{
 	# generated using "c3c --list-{} | string join ' '" in fish


### PR DESCRIPTION
`#!` is now highlighted (if at the beginning of a file) in C3 files with kakoune.