### PR TITLE
lite-xl: add contracts highlighting, fix vector [<*>] being interpreted as a contract

### DIFF
--- a/lite-xl/language_c3.lua
+++ b/lite-xl/language_c3.lua
@@ -48,6 +48,7 @@ syntax.add {
 	["case"]        = "keyword",
 	["catch"]       = "keyword",
 	["const"]       = "keyword",
+	["constdef"]    = "keyword",
 	["continue"]    = "keyword",
 	["default"]     = "keyword",
 	["defer"]       = "keyword",

--- a/lite-xl/language_c3.lua
+++ b/lite-xl/language_c3.lua
@@ -10,6 +10,7 @@ syntax.add {
 	patterns = {
 		{ pattern = "//.-\n",                   type = "comment"  },
 		{ pattern = { "/%*", "%*/" },           type = "comment"  },
+		{ pattern = "%[<%*>%]",                 type = "normal"   },
 		{ pattern = { "<%*", "%*>" },           type = "comment"  },
 		{ pattern = { '"', '"', '\\' },         type = "string"   },
 		{ pattern = { "`", "`", '\\' },         type = "string"   },

--- a/lite-xl/language_c3.lua
+++ b/lite-xl/language_c3.lua
@@ -2,6 +2,19 @@
 local syntax = require "core.syntax"
 
 syntax.add {
+	name = "C3 Contract",
+	files = { "%.c3contract$" },
+	patterns = {
+		{ pattern = {"@require", "\n"}, type = "keyword", syntax = ".c3" },
+		{ pattern = {"@ensure", "\n"}, type = "keyword", syntax = ".c3" },
+		{ pattern = {"@param", "\n"}, type = "keyword", syntax = ".c3" },
+		{ pattern = {"@pure", "\n"}, type = "keyword", syntax = ".c3" },
+		{ pattern = {"@return?", "\n"}, type = "keyword", syntax = ".c3" },
+		{ pattern = {"@deprecated", "\n"}, type = "keyword", syntax = ".c3" },
+	},
+}
+
+syntax.add {
 	name = "C3",
 	files = { "%.c3$", "%.c3i$", "%.c3t$" },
 	comment = "//",
@@ -11,7 +24,7 @@ syntax.add {
 		{ pattern = "//.-\n",                   type = "comment"  },
 		{ pattern = { "/%*", "%*/" },           type = "comment"  },
 		{ pattern = "%[<%*>%]",                 type = "normal"   },
-		{ pattern = { "<%*", "%*>" },           type = "comment"  },
+		{ pattern = { "<%*", "%*>" },           type = "comment", syntax = ".c3contract"  },
 		{ pattern = { '"', '"', '\\' },         type = "string"   },
 		{ pattern = { "`", "`", '\\' },         type = "string"   },
 		{ pattern = { "'", "'", '\\' },         type = "string"   },

--- a/lite-xl/language_c3.lua
+++ b/lite-xl/language_c3.lua
@@ -11,6 +11,7 @@ syntax.add {
 		{ pattern = {"@pure",       "\n"}, type = "keyword", syntax = ".c3" },
 		{ pattern = {"@return?",    "\n"}, type = "keyword", syntax = ".c3" },
 		{ pattern = {"@deprecated", "\n"}, type = "keyword", syntax = ".c3" },
+		{ pattern = ".",                   type = "comment" },
 	},
 }
 

--- a/lite-xl/language_c3.lua
+++ b/lite-xl/language_c3.lua
@@ -5,11 +5,11 @@ syntax.add {
 	name = "C3 Contract",
 	files = { "%.c3contract$" },
 	patterns = {
-		{ pattern = {"@require", "\n"}, type = "keyword", syntax = ".c3" },
-		{ pattern = {"@ensure", "\n"}, type = "keyword", syntax = ".c3" },
-		{ pattern = {"@param", "\n"}, type = "keyword", syntax = ".c3" },
-		{ pattern = {"@pure", "\n"}, type = "keyword", syntax = ".c3" },
-		{ pattern = {"@return?", "\n"}, type = "keyword", syntax = ".c3" },
+		{ pattern = {"@require",    "\n"}, type = "keyword", syntax = ".c3" },
+		{ pattern = {"@ensure",     "\n"}, type = "keyword", syntax = ".c3" },
+		{ pattern = {"@param",      "\n"}, type = "keyword", syntax = ".c3" },
+		{ pattern = {"@pure",       "\n"}, type = "keyword", syntax = ".c3" },
+		{ pattern = {"@return?",    "\n"}, type = "keyword", syntax = ".c3" },
 		{ pattern = {"@deprecated", "\n"}, type = "keyword", syntax = ".c3" },
 	},
 }


### PR DESCRIPTION
before:
<img width="894" height="795" alt="image" src="https://github.com/user-attachments/assets/5203c232-111e-405e-893b-962be47a2ed1" />


after:
<img width="897" height="797" alt="image" src="https://github.com/user-attachments/assets/3a952f51-dc86-4fff-9f1d-53bb7ec57281" />
